### PR TITLE
Update DbGetFnc.php

### DIFF
--- a/functions/DbGetFnc.php
+++ b/functions/DbGetFnc.php
@@ -70,7 +70,7 @@ function DBGet($QI,$functions=array(),$index=array())
 		{
                     if(strlen($value) == strlen(strip_tags($value)))
                     $value=  htmlentities($value);
-			if($functions[$key] && function_exists($functions[$key]))
+			if(isset($functions[$key]) && $functions[$key] && function_exists($functions[$key]))
 			{
 				if($index_count)
 					eval('$results'.$ind.'[$this_ind][$key] = $functions[$key]($value,$key);');


### PR DESCRIPTION
When error reporting is enabled, this file throws multiple errors due to line 73.  The variable $functions[$key] does not always exist, depending on what parameters are sent into the function.  Adding a "isset" check will stop error reporting from throwing errors when indexes don't exist.  Tested on my local copy of OpenSIS 7.6.  Seems to work without causing other errors.